### PR TITLE
introduce createController.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "transform": {
       "^.+\\.(ts|tsx)$": "<rootDir>/support/preprocessor.js"
     },
-    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$"
+    "testMatch": [
+      "**/__tests__/*.spec.(ts|tsx)"
+    ]
   }
 }

--- a/src/__tests__/controller.spec.ts
+++ b/src/__tests__/controller.spec.ts
@@ -1,0 +1,24 @@
+// tslint:disable-next-line:no-reference
+/// <reference path="./jasmine.matcher.d.ts" />
+
+import {} from "jasmine";
+import { createController, IController } from "../controller";
+import { customMatchers } from "./jasmine.matcher";
+
+class TestController implements IController {
+    public recievedArguments: any[];
+    constructor(...args: any[]) {
+        this.recievedArguments = args;
+    }
+}
+
+describe("Calatava.Controller", () => {
+    beforeEach(() => {
+        jasmine.addMatchers(customMatchers);
+    });
+    it("#createController should create instance of controller with given args",
+     () => {
+        const result = createController(TestController, {arg1: "1", arg2: "2"});
+        expect(result).toBeInstanceOf(TestController);
+    });
+});

--- a/src/__tests__/jasmine.matcher.d.ts
+++ b/src/__tests__/jasmine.matcher.d.ts
@@ -1,0 +1,9 @@
+declare namespace jasmine {
+    interface Matchers<T> {
+        toBeInstanceOf(expectedType: any): jasmine.CustomMatcher;
+    }
+    interface CustomMatcherResult {
+        pass: boolean;
+        message?: () => string;
+    }
+}

--- a/src/__tests__/jasmine.matcher.ts
+++ b/src/__tests__/jasmine.matcher.ts
@@ -1,0 +1,32 @@
+// tslint:disable-next-line:no-reference
+/// <reference path="./jasmine.matcher.d.ts" />
+import {} from "jasmine";
+
+const toBeInstanceOf = (expectedType: any): jasmine.CustomMatcher => {
+    const identify = (obj): string => {
+        return obj.name ? obj.name : obj.constructor.name;
+    };
+    return {
+        compare: (actual: any, expected: any): jasmine.CustomMatcherResult => {
+            const isPositive: boolean = actual instanceof expected;
+            let report = "";
+            if ( !isPositive ) {
+                report = `expected actual to be instance of ${expected.name}` +
+                    ` found ${identify(actual)} instead.`;
+            }
+            const result: jasmine.CustomMatcherResult = {
+                pass: isPositive,
+                message: () => report,
+            };
+            // tslint:disable-next-line:no-console
+            console.log(result);
+            return result;
+        },
+    };
+};
+
+const customMatchers: jasmine.CustomMatcherFactories = {
+    toBeInstanceOf,
+   };
+// tslint:disable-next-line:max-line-length
+export { toBeInstanceOf, customMatchers };

--- a/src/__tests__/router.spec.ts
+++ b/src/__tests__/router.spec.ts
@@ -1,4 +1,3 @@
-import {} from "jasmine";
 import { IController } from "../controller";
 import { RouteRedefineError } from "../errors";
 import { Router } from "../router";

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,2 +1,12 @@
 // tslint:disable-next-line:no-empty-interface
 export interface IController {}
+
+export interface ControllerCreator<T extends IController> {
+    new(...args: any[]): T;
+}
+
+export function createController<T extends IController>(
+    ctor: ControllerCreator<T>,
+    ...args: any[]): T {
+    return new ctor(...args);
+}

--- a/support/tsconfig.json
+++ b/support/tsconfig.json
@@ -14,6 +14,9 @@
             "node"
         ]
     },
+    "exclude": [
+        "**/__tests__/jasmine.matcher.d.ts"
+    ],
     "include" : [
         "../src/**/*.*",
         "**/__tests__/*.*"

--- a/tslint.json
+++ b/tslint.json
@@ -6,7 +6,8 @@
     "jsRules": {},
     "rules": {
         "max-classes-per-file":false,
-        "interface-name": false
+        "interface-name": false,
+        "object-literal-sort-keys": false
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
    given a controllerType createController returns an instance of
    Controller.

change jest test file matchers because testRegex to testMatch as regex
was matching non spec files too.

add custom jasmine matchers.
also added jasmine matchers definition file as CustomMatcherResult was
not able to understand message as function.

optimize some tslint rules